### PR TITLE
Control braking

### DIFF
--- a/firmware/.vscode/settings.json
+++ b/firmware/.vscode/settings.json
@@ -43,7 +43,8 @@
         "misc-include-cleaner",
         "readability-identifier-length",
         "altera-unroll-loops",
-        "cppcoreguidelines-avoid-non-const-global-variables"
+        "cppcoreguidelines-avoid-non-const-global-variables",
+        "bugprone-narrowing-conversions"
     ],
     "cSpell.words": [
         "anticogging"

--- a/firmware/src/BSP/motor.c
+++ b/firmware/src/BSP/motor.c
@@ -114,19 +114,19 @@ void field_oriented_control(int16_t current_target) {
 
 		//Qadrature axis
 		//U_q = I_q*R + U_emf
-		int16_t U_IR = (int16_t)((int32_t)I_q * phase_R / Ohm_to_mOhm);
+		int16_t U_IqR = (int16_t)((int32_t)I_q * phase_R / Ohm_to_mOhm);
 		int32_t U_emf = (int32_t)((int64_t)motor_k_bemf * speed_slow / (int32_t)ANGLE_STEPS);
-		int32_t U_q = U_IR + U_emf;
+		int32_t U_q = U_IqR + U_emf;
 		int16_t U_lim = (int16_t)min(GetMotorVoltage_mV(), INT16_MAX);
 		int16_t U_emf_sat = (int16_t)clip(U_emf, -U_lim, U_lim);
-		int16_t U_IR_sat = (int16_t)clip(U_IR, -U_lim - U_emf_sat, U_lim - U_emf_sat);
-		U_IR_sat = (int16_t)clip(U_IR_sat, -U_lim, U_lim);
-		int16_t U_q_sat = U_IR_sat + U_emf_sat;
-		int16_t I_q_act = (int16_t)((int32_t)U_IR_sat * Ohm_to_mOhm / phase_R);
+		int16_t U_IqR_sat = (int16_t)clip(U_IqR, -U_lim - U_emf_sat, U_lim - U_emf_sat);
+		U_IqR_sat = (int16_t)clip(U_IqR_sat, -U_lim, U_lim);
+		int16_t U_q_sat = U_IqR_sat + U_emf_sat;
+		int16_t I_q_act = (int16_t)((int32_t)U_IqR_sat * Ohm_to_mOhm / phase_R);
 		current_actual = I_q_act;
 
 		//Direct Axis
-		//U_d = I_q*ω*Rl
+		//U_d = -I_q*ω*L
 		uint16_t motor_rev_to_elec_rad = (uint16_t)((uint32_t)TWO_PI_X1024 * liveMotorParams.fullStepsPerRotation / 4U / 1024U); //typically 314 (or 628 for 0.9deg motor)
 		int32_t e_rad_s = (int32_t)((int64_t)motor_rev_to_elec_rad * speed_slow / (int32_t)ANGLE_STEPS);
 		int32_t U_d = (int32_t)((int64_t)(-I_q_act) * e_rad_s * phase_L / H_to_uH) ; //Vd=Iq * ω*Rl

--- a/firmware/swdio.MCUViewer.cfg
+++ b/firmware/swdio.MCUViewer.cfg
@@ -12,6 +12,10 @@ probe_type = 0
 target_name = 
 probe_mode = 0
 probe_speed_khz = 100
+probe_sn = 0675FF303435554157122856
+should_log = false
+log_directory = 
+gdb_command = gdb
 
 [trace_settings]
 core_frequency = 160000
@@ -25,40 +29,121 @@ probe_type = 0
 target_name = 
 probe_speed_khz = 10000
 probe_sn = 
+should_log = false
+log_directory = 
 
 [var0]
-name = control
+name = I_d_est
+tracked_name = I_d_est
+address = 536871366
 type = 4
-color = 4097767702
+color = 3597089906
+should_update_from_elf = true
+shift = 0
+mask = 4294967295
+high_level_type = 0
 
 [var1]
-name = control_actual
+name = I_q_est
+tracked_name = I_q_est
+address = 536871368
 type = 4
-color = 4055110110
+color = 3719338890
+should_update_from_elf = true
+shift = 0
+mask = 4294967295
+high_level_type = 0
 
 [var2]
-name = motor_k_bemf
+name = U_d_sat
+tracked_name = U_d_sat
+address = 536871370
 type = 4
-color = 2505489822
+color = 2992169425
+should_update_from_elf = true
+shift = 0
+mask = 4294967295
+high_level_type = 0
 
 [var3]
-name = speed_slow
-type = 6
-color = 729570740
+name = U_q_sat
+tracked_name = U_q_sat
+address = 536871372
+type = 4
+color = 3711161130
+should_update_from_elf = true
+shift = 0
+mask = 4294967295
+high_level_type = 0
 
 [var4]
-name = vbat_adc_mV
-type = 3
-color = 2311005231
+name = control
+tracked_name = control
+address = 536871634
+type = 4
+color = 4097767702
+should_update_from_elf = true
+shift = 0
+mask = 4294967295
+high_level_type = 0
 
 [var5]
+name = control_actual
+tracked_name = control_actual
+address = 536871640
+type = 4
+color = 4055110110
+should_update_from_elf = true
+shift = 0
+mask = 4294967295
+high_level_type = 0
+
+[var6]
+name = motor_k_bemf
+tracked_name = motor_k_bemf
+address = 536870914
+type = 4
+color = 2505489822
+should_update_from_elf = true
+shift = 0
+mask = 4294967295
+high_level_type = 0
+
+[var7]
+name = speed_slow
+tracked_name = speed_slow
+address = 536871456
+type = 6
+color = 729570740
+should_update_from_elf = true
+shift = 0
+mask = 4294967295
+high_level_type = 0
+
+[var8]
+name = vbat_adc_mV
+tracked_name = vbat_adc_mV
+address = 536871124
+type = 3
+color = 2311005231
+should_update_from_elf = true
+shift = 0
+mask = 4294967295
+high_level_type = 0
+
+[var9]
 name = vmot_adc_mV
+tracked_name = vmot_adc_mV
+address = 536871132
 type = 3
 color = 762710722
+should_update_from_elf = true
+shift = 0
+mask = 4294967295
+high_level_type = 0
 
 [plot0]
 name = Speed
-visibility = true
 type = 0
 
 [plot0-series0]
@@ -68,7 +153,6 @@ format = DEC
 
 [plot1]
 name = Values
-visibility = true
 type = 2
 
 [plot1-series0]
@@ -87,34 +171,70 @@ visibility = true
 format = DEC
 
 [plot2]
-name = control
-visibility = true
+name = current
 type = 0
 
 [plot2-series0]
-name = control
+name = I_d_est
 visibility = true
 format = DEC
 
 [plot2-series1]
-name = control_actual
+name = I_q_est
 visibility = true
+format = DEC
+
+[plot2-series2]
+name = control
+visibility = false
+format = DEC
+
+[plot2-series3]
+name = control_actual
+visibility = false
 format = DEC
 
 [plot3]
-name = kbemf
-visibility = true
+name = new plot0
 type = 0
 
-[plot3-series0]
-name = motor_k_bemf
+[plot4]
+name = voltage
+type = 0
+
+[plot4-series0]
+name = U_d_sat
 visibility = true
 format = DEC
 
-[plot3-series1]
+[plot4-series1]
+name = U_q_sat
+visibility = true
+format = DEC
+
+[plot4-series2]
 name = vmot_adc_mV
 visibility = true
 format = DEC
+
+[group0]
+name = default group
+
+[group0-plot0]
+name = Speed
+visibility = true
+
+[group0-plot1]
+name = Values
+visibility = false
+
+[group0-plot2]
+name = current
+visibility = true
+
+[group0-plot3]
+name = voltage
+visibility = true
 
 [trace_plot0]
 name = CH0


### PR DESCRIPTION
Attempt to fix some of the torque reduction mentioned https://github.com/dzid26/StepperServoCAN/issues/15 when speed increases against the torque ("braking").  

Torque reduction happens when current changes direction (starts regen) and DC link voltage raises. This tries to avoid regen. 
Ref: https://medium.com/ather-dev-blog/introducing-the-magic-twist-feature-in-the-450-apex-beyond-regenerative-braking-d255c2a205e1
